### PR TITLE
Problem with valid? method

### DIFF
--- a/lib/workflow_on_mongoid/workflow.rb
+++ b/lib/workflow_on_mongoid/workflow.rb
@@ -12,7 +12,7 @@ module Workflow
 
     private
       def write_initial_state
-        update_attribute(self.class.workflow_column, current_state.to_s) if load_workflow_state.blank?
+        send("#{self.class.workflow_column}=", current_state.to_s) if load_workflow_state.blank?
       end
   end
 


### PR DESCRIPTION
Hi. I got unexpected saving when call valid? method on new records. Because update_attribute save record. My patch fix it.

For example:
class Job
  include Mongoid::Document
  include Workflow

  belongs_to :user

  validates :user_id, :presence => true

  workflow do
    state :pending
    state :finished
  end
end

$ rails c

> > Mongoid.config.logger = Logger.new($stdout)
> > job = Job.new
> > job.valid?
> > MONGODB test['jobs'].insert([{"_id"=>BSON::ObjectId('4e0c4923af0e49180b000002'), "workflow_state"=>"pending"}])
> > => false  
> > -- I got here unexpected saving of unvalidated records!
