### PR TITLE
Workflow on mongoid works with mongo 2.1* too.

### DIFF
--- a/workflow_on_mongoid.gemspec
+++ b/workflow_on_mongoid.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.7"
  
   s.add_dependency "workflow", '~>0.8'
-  s.add_dependency "mongoid", '~>2.0.0.rc'
+  s.add_dependency "mongoid", '>=2.0.0.rc'
   s.add_dependency "bson_ext", '~>1.1'
 
   s.add_development_dependency "rake", '0.8.7'    
@@ -30,3 +30,4 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob("{bin,lib}/**/*") + %w(MIT_LICENSE README.rdoc)
   s.require_path = 'lib'
 end
+


### PR DESCRIPTION
Hi guys! Being me using mongoid (2.1.0 42ca85f), I've noticed that your gem is working well, so here's the pull request with updated dependencies.

Feel free to reject it if you want to be safer.

Regards.
