### PR TITLE
Remove bson_ext dependency for jruby

### DIFF
--- a/workflow_on_mongoid.gemspec
+++ b/workflow_on_mongoid.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "workflow", '~>0.8'
   s.add_dependency "mongoid", '>=2.0.0.rc.1'
-  s.add_dependency "bson_ext"
 
   s.add_development_dependency "rake", '0.9.2'
   s.add_development_dependency "rspec", '>=2.6.0'


### PR DESCRIPTION
Hi, could you please remove the bson_ext dependency from the gemspec, so that the gem can be run under jruby?  Note that bson_ext is optional for mongoid (will use if found); the bson gem contains a java version of bson that's used under a jruby environment.
