### PR TITLE
Warning on "include" order

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,8 @@ NOTE: workflow_on_mongoid 0.8.0 uses Mongoid 2.0.0.beta.20 . 0.8.0.1+ uses the l
     field :title
     field :status
 
-    include Workflow
+    include Workflow    # Note this *must* occur after at least one 
+                        # Mongoid::* include, otherwise your status will not be persisted.
 
     workflow_column :status
 
@@ -41,6 +42,7 @@ NOTE: workflow_on_mongoid 0.8.0 uses Mongoid 2.0.0.beta.20 . 0.8.0.1+ uses the l
   end
 
 See the {tests for Mongoid}[http://github.com/bowsersenior/workflow_on_mongoid/blob/master/test/mongoid_test.rb] for more examples.
+Do ensure your <code>include Workflow</code> line occurs after at least one <code>Mongoid::Include</code> line.
 
 == Tests
 


### PR DESCRIPTION
Hi,

Thanks for the gem - this is exactly what I need.

Have updated README.rdoc to include a warning about ordering your includes correctly - I had Workflow first in my list rather than after any Mongoid includes and wondered why my statuses weren't being persisted :)

Had a quick look at how WOM figures out how it's in a Mongoid object and have updated the README with an explicit warning in the example.

Cheers,

Russ
